### PR TITLE
Add localStorage persistence for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ A single-page webapp (`index.html`) lets you practice Chinese conversation using
 4. Click **Stop** at any time to end the conversation.
 
 All requests are made directly from the browser, so your API key is never sent anywhere except the OpenAI API.
+Your key is saved in your browser's localStorage so it will be there next time you open the page.

--- a/script.js
+++ b/script.js
@@ -12,6 +12,17 @@ const recordBtn = document.getElementById('recordButton');
 const transcriptDiv = document.getElementById('transcript');
 const ttsAudio = document.getElementById('ttsAudio');
 
+// Load stored API key if present
+const savedKey = localStorage.getItem('openai_api_key');
+if (savedKey) {
+  apiKeyInput.value = savedKey;
+}
+
+// Save API key whenever it changes
+apiKeyInput.addEventListener('input', () => {
+  localStorage.setItem('openai_api_key', apiKeyInput.value);
+});
+
 startStopBtn.addEventListener('click', () => {
   if (!running) {
     startConversation();


### PR DESCRIPTION
## Summary
- save OpenAI API key in browser `localStorage`
- restore key on page load
- note persistence in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a905e4af083219af9e10feb14c08f