### PR TITLE
Add press-and-hold recording button

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,20 @@
 <style>
 body { font-family: Arial, sans-serif; margin: 20px; }
 #transcript { border: 1px solid #ccc; padding: 10px; height: 200px; width: 100%; overflow-y: auto; white-space: pre-wrap; }
-#recordButton { margin-left: 10px; }
+#talkButton {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: none;
+  background-color: #4CAF50;
+  color: white;
+  font-size: 12px;
+  margin-top: 10px;
+}
+#talkButton.holding {
+  background-color: #45A049;
+  transform: scale(0.95);
+}
 </style>
 </head>
 <body>
@@ -15,8 +28,8 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 <label>OpenAI API Key: <input type="password" id="apiKey"></label><br><br>
 <textarea id="scenario" rows="3" cols="60" placeholder="Describe your practice scenario here..."></textarea><br>
 <button id="startStop">Go</button>
-<button id="recordButton" disabled>Record</button>
 <div id="transcript"></div>
+<button id="talkButton" disabled>说话时按住 (Press and hold while speaking)</button>
 <audio id="ttsAudio"></audio>
 <script src="script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- replace the Record button with a large circular "talk" button
- press or hold space to record, release to send
- disable and update the button text while the teacher is speaking

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a904b8db883219542c8abd728e4a2