### PR TITLE
Add OpenCC conversion for transcripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,7 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 </div>
 
 <audio id="ttsAudio"></audio>
+<script src="https://unpkg.com/opencc-js@1.0.5/dist/browser.min.js"></script>
 <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,9 @@ let recording = false;
 // instructions sent to the assistant
 const systemPrompt = `You are a friendly Chinese teacher named 小王. Hold conversational practice with the learner:\n- Speak mostly Simplified Mandarin Chinese, sprinkling English only when necessary for comprehension.\n- Subtly correct grammar, vocabulary and pronunciation after each learner utterance.\n- If the learner says "word是什么？", give the English meaning.\n- If learner asks about a grammar structure, explain briefly in English followed by a Chinese example.\n- Begin now with the scenario the learner provided.`;
 
+// converter for Traditional -> Simplified
+const toSimplified = OpenCC.Converter({ from: 'tw', to: 'cn' });
+
 // grab page elements
 const apiKeyInput = document.getElementById('apiKey');
 const scenarioInput = document.getElementById('scenario');
@@ -207,7 +210,7 @@ async function sendUserAudio(blob) {
     body: formData
   });
   const sttData = await sttResponse.json();
-  const userText = sttData.text;
+  const userText = toSimplified(sttData.text);
   conversation.push({ role: 'user', content: userText });
   transcriptDiv.textContent += `\n我: ${userText}`;
   scrollTranscriptToBottom();


### PR DESCRIPTION
## Summary
- load opencc-js in the HTML page
- convert transcribed Traditional Chinese to Simplified Chinese before sending to the API or displaying it

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684aa19e36188321bbcff0b0ddb1f39e