### PR TITLE
Add collapsible header when starting conversation

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
 <style>
 body { font-family: Arial, sans-serif; margin: 20px; }
 
+/* collapsible header */
+#header { overflow: hidden; transition: max-height 0.3s ease, opacity 0.3s ease; max-height: 1000px; }
+#header.collapsed { max-height: 0; opacity: 0; pointer-events: none; }
+#toggleHeader { display: none; position: fixed; top: 10px; right: 10px; font-size: 1.5em; cursor: pointer; }
+
 /* conversation transcript box */
 #transcript {
   border: 1px solid #ccc;
@@ -77,6 +82,7 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 </style>
 </head>
 <body>
+<div id="header">
 <h1>Chinese Conversation Practice</h1>
 <label>OpenAI API Key: <input type="password" id="apiKey"></label><br><br>
 <!-- practice scenario description -->
@@ -103,6 +109,8 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 - Asking for recommendations"></textarea><br>
 <!-- start or end the session -->
 <button id="startStop">Go</button>
+</div>
+<button id="toggleHeader">▼</button>
 
 <!-- conversation transcript -->
 <div id="transcript"></div>

--- a/script.js
+++ b/script.js
@@ -21,6 +21,8 @@ const transcriptDiv = document.getElementById('transcript');
 const ttsAudio = document.getElementById('ttsAudio');
 const repeatBtn = document.getElementById('repeatButton');
 const translateBtn = document.getElementById('translateButton');
+const headerDiv = document.getElementById('header');
+const toggleHeader = document.getElementById('toggleHeader');
 let lastAssistantText = '';
 
 // keep transcript scrolled to bottom
@@ -48,6 +50,12 @@ startStopBtn.addEventListener('click', () => {
   } else {
     stopConversation();
   }
+});
+
+// expand hidden header when arrow clicked
+toggleHeader.addEventListener('click', () => {
+  headerDiv.classList.remove('collapsed');
+  toggleHeader.style.display = 'none';
 });
 
 // begin recording when holding the button
@@ -138,6 +146,8 @@ async function startConversation() {
     return;
   }
   running = true;
+  headerDiv.classList.add('collapsed');
+  toggleHeader.style.display = 'block';
   startStopBtn.textContent = 'Stop';
   transcriptDiv.textContent = '';
   repeatBtn.disabled = true;
@@ -158,6 +168,8 @@ function stopConversation() {
   if (recording) {
     mediaRecorder.stop();
   }
+  headerDiv.classList.remove('collapsed');
+  toggleHeader.style.display = 'none';
   startStopBtn.textContent = 'Go';
   repeatBtn.disabled = true;
   translateBtn.disabled = true;


### PR DESCRIPTION
## Summary
- add collapsible header styling and toggle arrow button
- hide header when conversation starts and restore when stopped

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684aa91235fc8321b83c4b55d5cf0480