### PR TITLE
Add translation button cooldown and disabled styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,9 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 #repeatButton:disabled {
   background-color: grey;
 }
+#translateButton:disabled {
+  background-color: grey;
+}
 #repeatButton:active, #translateButton:active {
   transform: scale(0.95);
 }

--- a/script.js
+++ b/script.js
@@ -125,6 +125,7 @@ translateBtn.addEventListener('click', async () => {
     const eng = data.choices[0].message.content.trim();
     transcriptDiv.textContent += ` (${eng})`;
     scrollTranscriptToBottom();
+    translateBtn.disabled = true;
   }
 });
 


### PR DESCRIPTION
## Summary
- style the translate button when disabled
- disable translate button after displaying a translation so it can only be used once per response

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ab0712bb8832193d8c4ad72d12b56