### PR TITLE
Update layout for control buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,42 +50,44 @@ body { font-family: Arial, sans-serif; margin: 20px; }
   position: relative;
   box-sizing: border-box;
   margin-top: 40px;
+  margin-bottom: calc(50vh - 40px);
 }
 
 #talkButton {
   /* record button style */
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
   border: none;
   background-color: #4CAF50;
   color: white;
-  font-size: 12px;
-  margin-top: 10px;
+  font-size: 1em;
+  grid-row: 1 / span 2;
+  grid-column: 1;
 }
 #repeatButton {
   /* repeat button style */
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
   border: none;
   background-color: #2196F3;
   color: white;
-  font-size: 12px;
-  margin-top: 10px;
-  margin-right: 10px;
+  font-size: 1em;
+  grid-row: 1;
+  grid-column: 2;
 }
 #translateButton {
   /* english button style */
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
   border: none;
   background-color: #FFEB3B;
   color: black;
-  font-size: 12px;
-  margin-top: 10px;
-  margin-left: 10px;
+  font-size: 1em;
+  grid-row: 2;
+  grid-column: 2;
 }
 #repeatButton:disabled {
   background-color: grey;
@@ -97,10 +99,15 @@ body { font-family: Arial, sans-serif; margin: 20px; }
   transform: scale(0.95);
 }
 #controls {
-  display: flex;
-  justify-content: center;
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  right: 20px;
+  height: calc(50vh - 40px);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
   gap: 10px;
-  margin-top: 10px;
 }
 #talkButton.holding {
   /* button pressed state */


### PR DESCRIPTION
## Summary
- redesign control area to fill space under transcript
- use grid layout so the main speak button occupies the left half while the two other controls stack on the right
- style buttons as rounded rectangles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ab2a676f48321a443c4be94b029b4