### PR TITLE
Fix premature stop of audio recording

### DIFF
--- a/script.js
+++ b/script.js
@@ -58,9 +58,10 @@ startStopBtn.addEventListener('click', () => {
   }
 });
 
-// begin recording when holding the button
+// begin recording while pointer is held down
 talkBtn.addEventListener('pointerdown', (e) => {
   if (!talkBtn.disabled && !recording) {
+    talkBtn.setPointerCapture(e.pointerId);
     startRecording();
   }
 });
@@ -68,12 +69,13 @@ talkBtn.addEventListener('pointerdown', (e) => {
 // stop recording when released
 talkBtn.addEventListener('pointerup', (e) => {
   if (recording) {
+    talkBtn.releasePointerCapture(e.pointerId);
     stopRecording();
   }
 });
 
-// cancel if pointer leaves button
-talkBtn.addEventListener('pointerleave', (e) => {
+// handle unexpected pointer cancellation
+talkBtn.addEventListener('pointercancel', (e) => {
   if (recording) {
     stopRecording();
   }


### PR DESCRIPTION
## Summary
- keep pointer events captured on the record button
- handle pointer cancel event

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bf77a94b88321a3852060890a3755