### PR TITLE
Add modern web vocoder UI and playback effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,167 +1,240 @@
 <!DOCTYPE html>
-<!-- Main page for the conversation app -->
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Chinese Conversation Practice</title>
-<!-- Basic styling -->
-<style>
-body { font-family: Arial, sans-serif; margin: 20px; }
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Web Vocoder Playground</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #0f172a;
+      --card: #111827;
+      --accent: #22c55e;
+      --text: #e5e7eb;
+      --muted: #9ca3af;
+      --border: #1f2937;
+    }
 
-  /* floating header box */
-  #headerBox {
-    position: fixed;
-    top: 40px;
-    left: 10px;
-    right: 10px;
-    background: rgba(255,255,255,0.95);
-    border: 1px solid #ccc;
-    border-radius: 8px;
-    padding: 10px;
-    z-index: 100;
-    transition: transform 0.3s ease, opacity 0.3s ease;
-  }
-  #headerBox.collapsed {
-    transform: translateY(-120%);
-    opacity: 0;
-  }
-  #toggleHeader {
-    position: fixed;
-    top: 10px;
-    left: 10px;
-    background: #eee;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    padding: 2px 6px;
-    cursor: pointer;
-    z-index: 150;
-  }
+    * { box-sizing: border-box; }
 
-/* conversation transcript box */
-#transcript {
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  padding: 10px;
-  height: 40vh;
-  width: 100%;
-  overflow-y: auto;
-  white-space: pre-wrap;
-  font-size: 1.5em;
-  position: relative;
-  box-sizing: border-box;
-  margin-top: 40px;
-  margin-bottom: calc(50vh - 40px);
-}
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background: radial-gradient(circle at 10% 20%, #1f2937 0, #0f172a 30%),
+                  radial-gradient(circle at 80% 10%, #111827 0, #0f172a 35%),
+                  #0f172a;
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 32px 16px 48px;
+    }
 
-#talkButton {
-  /* record button style */
-  width: 100%;
-  height: 100%;
-  border-radius: 12px;
-  border: none;
-  background-color: #4CAF50;
-  color: white;
-  font-size: 1em;
-  grid-row: 1 / span 2;
-  grid-column: 1;
-}
-#repeatButton {
-  /* repeat button style */
-  width: 100%;
-  height: 100%;
-  border-radius: 12px;
-  border: none;
-  background-color: #2196F3;
-  color: white;
-  font-size: 1em;
-  grid-row: 1;
-  grid-column: 2;
-}
-#translateButton {
-  /* english button style */
-  width: 100%;
-  height: 100%;
-  border-radius: 12px;
-  border: none;
-  background-color: #FFEB3B;
-  color: white;
-  font-size: 1em;
-  grid-row: 2;
-  grid-column: 2;
-}
-#repeatButton:disabled {
-  background-color: grey;
-}
-#translateButton:disabled {
-  background-color: grey;
-}
-#repeatButton:active, #translateButton:active {
-  transform: scale(0.95);
-}
-#controls {
-  position: fixed;
-  bottom: 20px;
-  left: 20px;
-  right: 20px;
-  height: calc(50vh - 40px);
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
-  gap: 10px;
-}
-#talkButton.holding {
-  /* button pressed state */
-  background-color: #45A049;
-  transform: scale(0.95);
-}
+    main {
+      width: min(1100px, 100%);
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 20px;
+    }
 
-</style>
+    .panel {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 20px;
+      box-shadow: 0 15px 40px rgba(0, 0, 0, 0.25);
+    }
+
+    header {
+      grid-column: 1 / -1;
+      text-align: center;
+      padding: 8px 0 12px;
+    }
+
+    h1 {
+      margin: 0 0 8px;
+      font-size: clamp(28px, 3vw, 36px);
+      letter-spacing: -0.5px;
+    }
+
+    p.lead {
+      margin: 0;
+      color: var(--muted);
+      font-size: 16px;
+    }
+
+    .record-card {
+      display: grid;
+      gap: 12px;
+    }
+
+    .record-button {
+      width: 100%;
+      padding: 16px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: linear-gradient(135deg, #16a34a, #22c55e);
+      color: #0b1425;
+      font-size: 16px;
+      font-weight: 700;
+      letter-spacing: 0.25px;
+      cursor: pointer;
+      transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+    }
+
+    .record-button:disabled {
+      cursor: not-allowed;
+      filter: grayscale(0.6);
+      opacity: 0.8;
+    }
+
+    .record-button:active:not(:disabled) {
+      transform: translateY(1px);
+      box-shadow: 0 8px 30px rgba(34, 197, 94, 0.35);
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: #0b1221;
+      border: 1px solid var(--border);
+      color: var(--muted);
+      padding: 10px 12px;
+      border-radius: 12px;
+      font-size: 14px;
+    }
+
+    .chip svg { flex: none; }
+
+    .status {
+      min-height: 26px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .grid-buttons {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 10px;
+    }
+
+    .effect-button {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: #0b1221;
+      color: var(--text);
+      padding: 14px 12px;
+      text-align: left;
+      cursor: pointer;
+      transition: border-color 120ms ease, transform 120ms ease, background 120ms ease;
+    }
+
+    .effect-button:hover:not(:disabled) {
+      border-color: #334155;
+      transform: translateY(-1px);
+    }
+
+    .effect-button:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    .effect-title { font-weight: 700; display: block; }
+    .effect-desc { color: var(--muted); font-size: 13px; margin-top: 2px; display: block; }
+
+    .note {
+      grid-column: 1 / -1;
+      color: var(--muted);
+      font-size: 13px;
+      text-align: center;
+    }
+
+    .log {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      max-height: 260px;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 14px;
+    }
+
+    .log li {
+      background: #0b1221;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 12px;
+      color: var(--muted);
+    }
+
+    @media (max-width: 640px) {
+      body { padding: 20px 12px 32px; }
+      .grid-buttons { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
+    }
+  </style>
 </head>
 <body>
-<div id="toggleHeader">▲</div>
-<div id="headerBox">
-<h1>Chinese Conversation Practice</h1>
-<label>OpenAI API Key: <input type="password" id="apiKey"></label><br><br>
-<!-- practice scenario description -->
-<textarea id="scenario" rows="3" cols="60" placeholder="Describe your practice scenario here...
-- Ordering food at a restaurant
-- Shopping at a store or market
-- Asking for directions
-- Taking a taxi or ride share
-- Using public transportation
-- Checking into a hotel or Airbnb
-- Going to a doctor or pharmacy
-- Talking with a landlord or about your apartment
-- Paying bills or using mobile payment apps
-- Small talk with neighbors or locals
-- Introducing yourself and exchanging contact info
-- Making or declining plans with friends
-- Talking about your job or studies
-- Asking someone for help or clarification
-- Making a phone call
-- Reporting something lost or stolen
-- Handling a misunderstanding or disagreement
-- Explaining a personal emergency or health issue
-- Booking tickets
-- Asking for recommendations"></textarea><br>
-<!-- start or end the session -->
-<button id="startStop">Go</button>
-</div>
+  <main>
+    <header>
+      <h1>Vocoder Playground</h1>
+      <p class="lead">Record your voice, then hear it transformed with modern web audio effects.</p>
+    </header>
 
-<!-- conversation transcript -->
-<div id="transcript"></div>
-<div id="controls">
-  <!-- hold to record your voice -->
-  <button id="talkButton" disabled>说话时按住 (Press and hold while speaking)</button>
-  <!-- replay last teacher reply -->
-  <button id="repeatButton" disabled>请再说一次</button>
-  <!-- show english translation -->
-  <button id="translateButton" disabled>看看英文</button>
-</div>
+    <section class="panel record-card">
+      <div class="chip" id="micStatus">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 1a3 3 0 0 0-3 3v6a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+          <path d="M19 10a7 7 0 0 1-14 0" />
+          <line x1="12" x2="12" y1="19" y2="23" />
+          <line x1="8" x2="16" y1="23" y2="23" />
+        </svg>
+        Microphone ready
+      </div>
+      <button id="recordButton" class="record-button">Tap to record</button>
+      <div class="status" id="status">Waiting to record…</div>
+    </section>
 
-<audio id="ttsAudio"></audio>
-<script src="https://cdn.jsdelivr.net/npm/opencc-js@1.0.5/dist/umd/full.js"></script>
-<script src="script.js"></script>
+    <section class="panel">
+      <h2 style="margin-top: 0; margin-bottom: 12px;">Play it back</h2>
+      <p class="lead" style="margin-bottom: 16px;">Choose an effect to hear your take in different styles.</p>
+      <div class="grid-buttons">
+        <button class="effect-button" id="normalBtn" disabled>
+          <span class="effect-title">Clean</span>
+          <span class="effect-desc">Your voice, untouched.</span>
+        </button>
+        <button class="effect-button" id="echoBtn" disabled>
+          <span class="effect-title">Echo</span>
+          <span class="effect-desc">Feedback delay for spacious sound.</span>
+        </button>
+        <button class="effect-button" id="robotBtn" disabled>
+          <span class="effect-title">Robot</span>
+          <span class="effect-desc">Metallic ring modulation.</span>
+        </button>
+        <button class="effect-button" id="chipmunkBtn" disabled>
+          <span class="effect-title">Chipmunk</span>
+          <span class="effect-desc">Higher pitch &amp; speed.</span>
+        </button>
+        <button class="effect-button" id="deepBtn" disabled>
+          <span class="effect-title">Deep</span>
+          <span class="effect-desc">Slower, lower take.</span>
+        </button>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2 style="margin-top: 0; margin-bottom: 12px;">Session log</h2>
+      <p class="lead" style="margin-bottom: 16px;">We keep a brief history so you always know what happened.</p>
+      <ul class="log" id="log"></ul>
+    </section>
+
+    <p class="note">All processing happens locally in your browser using the Web Audio API. No audio ever leaves your device.</p>
+  </main>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,282 +1,220 @@
-// conversation history
-let conversation = [];
-// recorder objects
+const recordButton = document.getElementById('recordButton');
+const micStatus = document.getElementById('micStatus');
+const statusText = document.getElementById('status');
+const logList = document.getElementById('log');
+
+const normalBtn = document.getElementById('normalBtn');
+const echoBtn = document.getElementById('echoBtn');
+const robotBtn = document.getElementById('robotBtn');
+const chipmunkBtn = document.getElementById('chipmunkBtn');
+const deepBtn = document.getElementById('deepBtn');
+
 let mediaRecorder;
-let audioChunks = [];
-// flags for UI state
-let running = false;
-let recording = false;
-// instructions sent to the assistant
-const systemPrompt = `You are a friendly Chinese teacher named 小王. Hold conversational practice with the learner:\n- Speak mostly Simplified Mandarin Chinese, sprinkling English only when necessary for comprehension.\n- Subtly correct grammar, vocabulary and pronunciation after each learner utterance.\n- If the learner says "word是什么？", give the English meaning.\n- If learner asks about a grammar structure, explain briefly in English followed by a Chinese example.\n- Begin now with the scenario the learner provided.`;
+let recordedChunks = [];
+let audioBuffer = null;
+let isRecording = false;
+let audioContext;
 
-// converter for Traditional -> Simplified
-const toSimplified = OpenCC.Converter({ from: 'tw', to: 'cn' });
-
-// grab page elements
-const apiKeyInput = document.getElementById('apiKey');
-const scenarioInput = document.getElementById('scenario');
-const startStopBtn = document.getElementById('startStop');
-const talkBtn = document.getElementById('talkButton');
-const transcriptDiv = document.getElementById('transcript');
-const ttsAudio = document.getElementById('ttsAudio');
-const repeatBtn = document.getElementById('repeatButton');
-const translateBtn = document.getElementById('translateButton');
-const headerBox = document.getElementById('headerBox');
-const toggleHeader = document.getElementById('toggleHeader');
-let lastAssistantText = '';
-
-// keep transcript scrolled to bottom
-function scrollTranscriptToBottom() {
-  transcriptDiv.scrollTop = transcriptDiv.scrollHeight;
+function addLog(message) {
+  const item = document.createElement('li');
+  const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  item.textContent = `[${time}] ${message}`;
+  logList.prepend(item);
 }
 
-// Load stored API key if present
-const savedKey = localStorage.getItem('openai_api_key');
-if (savedKey) {
-  apiKeyInput.value = savedKey;
+function setPlaybackEnabled(enabled) {
+  [normalBtn, echoBtn, robotBtn, chipmunkBtn, deepBtn].forEach(btn => {
+    btn.disabled = !enabled;
+  });
 }
 
-// Save API key whenever it changes
-apiKeyInput.addEventListener('input', () => {
-  localStorage.setItem('openai_api_key', apiKeyInput.value);
-});
-
-// show or hide the header box
-toggleHeader.addEventListener('click', () => {
-  headerBox.classList.toggle('collapsed');
-  toggleHeader.textContent = headerBox.classList.contains('collapsed') ? '▼' : '▲';
-});
-
-// start or stop the conversation
-startStopBtn.addEventListener('click', () => {
-  // remove focus so holding Space doesn't trigger another click
-  startStopBtn.blur();
-  if (!running) {
-    startConversation();
-  } else {
-    stopConversation();
+async function initMic() {
+  try {
+    await navigator.mediaDevices.getUserMedia({ audio: true });
+    micStatus.textContent = 'Microphone ready';
+    addLog('Microphone permission granted.');
+  } catch (err) {
+    micStatus.textContent = 'Microphone blocked — allow access to record';
+    addLog('Microphone access was denied. Please enable it and reload.');
+    recordButton.disabled = true;
   }
-});
-
-// begin recording when holding the button
-talkBtn.addEventListener('pointerdown', (e) => {
-  if (!talkBtn.disabled && !recording) {
-    startRecording();
-  }
-});
-
-// stop recording when released
-talkBtn.addEventListener('pointerup', (e) => {
-  if (recording) {
-    stopRecording();
-  }
-});
-
-// cancel if pointer leaves button
-talkBtn.addEventListener('pointerleave', (e) => {
-  if (recording) {
-    stopRecording();
-  }
-});
-
-// allow recording with spacebar
-document.addEventListener('keydown', (e) => {
-  if (e.code === 'Space' && !talkBtn.disabled && !recording) {
-    e.preventDefault();
-    startRecording();
-  }
-});
-
-// stop recording when spacebar released
-document.addEventListener('keyup', (e) => {
-  if (e.code === 'Space' && recording) {
-    e.preventDefault();
-    stopRecording();
-  }
-});
-
-// speak again when repeat button clicked
-repeatBtn.addEventListener('click', async () => {
-  const apiKey = apiKeyInput.value.trim();
-  if (lastAssistantText && apiKey) {
-    await speakAssistantText(apiKey, lastAssistantText);
-  }
-});
-
-// translate last teacher reply when clicked
-translateBtn.addEventListener('click', async () => {
-  const apiKey = apiKeyInput.value.trim();
-  if (lastAssistantText && apiKey) {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o',
-        messages: [
-          { role: 'system', content: 'Translate the following Chinese text to English succinctly.' },
-          { role: 'user', content: lastAssistantText }
-        ]
-      })
-    });
-    const data = await response.json();
-    const eng = data.choices[0].message.content.trim();
-    transcriptDiv.textContent += ` (${eng})`;
-    scrollTranscriptToBottom();
-    translateBtn.disabled = true;
-  }
-});
-
-// enable mic after audio playback
-ttsAudio.addEventListener('ended', () => {
-  if (running) {
-    talkBtn.disabled = false;
-    talkBtn.textContent = '说话时按住 (Press and hold while speaking)';
-    repeatBtn.disabled = false;
-    translateBtn.disabled = false;
-  }
-});
-
-// begin a new chat session
-async function startConversation() {
-  const apiKey = apiKeyInput.value.trim();
-  if (!apiKey) {
-    alert('Please enter your OpenAI API key.');
-    return;
-  }
-  running = true;
-  startStopBtn.textContent = 'Stop';
-  headerBox.classList.add('collapsed');
-  toggleHeader.textContent = '▼';
-  transcriptDiv.textContent = '';
-  repeatBtn.disabled = true;
-  translateBtn.disabled = true;
-  talkBtn.textContent = '老师正在讲话 (Teacher is speaking)...';
-  talkBtn.disabled = true;
-  conversation = [
-    { role: 'system', content: systemPrompt },
-    { role: 'user', content: scenarioInput.value.trim() }
-  ];
-  console.log('Starting conversation');
-  await getAssistantResponse(apiKey);
 }
 
-// reset UI and stop any recording
-function stopConversation() {
-  running = false;
-  if (recording) {
-    mediaRecorder.stop();
-  }
-  startStopBtn.textContent = 'Go';
-  headerBox.classList.remove('collapsed');
-  toggleHeader.textContent = '▲';
-  repeatBtn.disabled = true;
-  translateBtn.disabled = true;
-  talkBtn.disabled = true;
-  talkBtn.textContent = '说话时按住 (Press and hold while speaking)';
-  console.log('Conversation stopped');
-}
-
-// start capturing microphone input
 async function startRecording() {
-  if (!running) return;
-  talkBtn.textContent = '现在讲 (Speak now)';
-  talkBtn.classList.add('holding');
-  recording = true;
-  audioChunks = [];
-  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-  mediaRecorder = new MediaRecorder(stream);
-  mediaRecorder.start();
-  mediaRecorder.addEventListener('dataavailable', event => {
-    audioChunks.push(event.data);
-  });
-  mediaRecorder.addEventListener('stop', async () => {
-    const audioBlob = new Blob(audioChunks, { type: 'audio/webm' });
-    console.log('Recording stopped, sending to OpenAI');
-    await sendUserAudio(audioBlob);
-    stream.getTracks().forEach(t => t.stop());
+  if (isRecording) return;
+  recordedChunks = [];
+  isRecording = true;
+  statusText.textContent = 'Recording… tap again to stop.';
+  recordButton.textContent = 'Stop recording';
+  setPlaybackEnabled(false);
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    mediaRecorder = new MediaRecorder(stream, { mimeType: 'audio/webm' });
+
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data.size > 0) {
+        recordedChunks.push(event.data);
+      }
+    };
+
+    mediaRecorder.onstop = async () => {
+      stream.getTracks().forEach(t => t.stop());
+      isRecording = false;
+      recordButton.textContent = 'Tap to record';
+      const blob = new Blob(recordedChunks, { type: 'audio/webm' });
+      await decodeRecording(blob);
+    };
+
+    mediaRecorder.start();
+    addLog('Recording started.');
+  } catch (error) {
+    isRecording = false;
+    recordButton.textContent = 'Tap to record';
+    statusText.textContent = 'Could not start recording — check microphone access.';
+    addLog('Recording failed to start: ' + error.message);
+  }
+}
+
+async function decodeRecording(blob) {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+
+  try {
+    statusText.textContent = 'Processing your take…';
+    const arrayBuffer = await blob.arrayBuffer();
+    audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+    statusText.textContent = 'Ready. Tap an effect to listen.';
+    addLog('Recording processed and ready for playback.');
+    setPlaybackEnabled(true);
+  } catch (error) {
+    statusText.textContent = 'Processing failed. Please record again.';
+    addLog('Failed to decode audio: ' + error.message);
+  }
+}
+
+function playBuffer(setupNodes) {
+  if (!audioBuffer || !audioContext) return;
+
+  const source = audioContext.createBufferSource();
+  source.buffer = audioBuffer;
+
+  const destination = audioContext.destination;
+  let nodeChainEnd = setupNodes ? setupNodes(source) : source;
+  if (!nodeChainEnd) nodeChainEnd = source;
+  nodeChainEnd.connect(destination);
+  source.start();
+}
+
+function createEchoChain(source) {
+  const delay = audioContext.createDelay(5.0);
+  delay.delayTime.value = 0.24;
+
+  const feedback = audioContext.createGain();
+  feedback.gain.value = 0.32;
+
+  const filter = audioContext.createBiquadFilter();
+  filter.type = 'lowpass';
+  filter.frequency.value = 3200;
+
+  source.connect(delay);
+  delay.connect(filter);
+  filter.connect(feedback);
+  feedback.connect(delay);
+
+  const dryGain = audioContext.createGain();
+  dryGain.gain.value = 0.75;
+
+  const wetGain = audioContext.createGain();
+  wetGain.gain.value = 0.65;
+
+  source.connect(dryGain);
+  delay.connect(wetGain);
+
+  const merger = audioContext.createGain();
+  dryGain.connect(merger);
+  wetGain.connect(merger);
+
+  return merger;
+}
+
+function createRobotChain(source) {
+  const modOsc = audioContext.createOscillator();
+  modOsc.frequency.value = 30;
+
+  const modGain = audioContext.createGain();
+  modGain.gain.value = 0.7;
+
+  modOsc.connect(modGain);
+
+  const ringMod = audioContext.createGain();
+  source.connect(ringMod.gain);
+  modGain.connect(ringMod);
+  modOsc.start();
+
+  const comb = audioContext.createDelay();
+  comb.delayTime.value = 0.005;
+  ringMod.connect(comb);
+
+  const filter = audioContext.createBiquadFilter();
+  filter.type = 'bandpass';
+  filter.frequency.value = 1400;
+  filter.Q.value = 1.2;
+
+  comb.connect(filter);
+  return filter;
+}
+
+function playNormal() {
+  statusText.textContent = 'Playing clean take…';
+  addLog('Playing: Clean');
+  playBuffer((source) => source);
+}
+
+function playEcho() {
+  statusText.textContent = 'Playing with echo…';
+  addLog('Playing: Echo');
+  playBuffer(createEchoChain);
+}
+
+function playRobot() {
+  statusText.textContent = 'Playing with robot tone…';
+  addLog('Playing: Robot');
+  playBuffer(createRobotChain);
+}
+
+function playChipmunk() {
+  statusText.textContent = 'Playing fast & bright…';
+  addLog('Playing: Chipmunk');
+  playBuffer((source) => {
+    source.playbackRate.value = 1.35;
+    return source;
   });
 }
 
-// finish the current recording
-function stopRecording() {
-  if (!recording) return;
-  talkBtn.textContent = '老师正在讲话 (Teacher is speaking)...';
-  talkBtn.classList.remove('holding');
-  recording = false;
-  mediaRecorder.stop();
-  talkBtn.disabled = true;
-}
-
-// transcribe audio then ask GPT
-async function sendUserAudio(blob) {
-  const apiKey = apiKeyInput.value.trim();
-  const formData = new FormData();
-  formData.append('file', blob, 'speech.webm');
-  formData.append('model', 'gpt-4o-transcribe');
-
-  const sttResponse = await fetch('https://api.openai.com/v1/audio/transcriptions', {
-    method: 'POST',
-    headers: { 'Authorization': `Bearer ${apiKey}` },
-    body: formData
+function playDeep() {
+  statusText.textContent = 'Playing slower & lower…';
+  addLog('Playing: Deep');
+  playBuffer((source) => {
+    source.playbackRate.value = 0.75;
+    return source;
   });
-  const sttData = await sttResponse.json();
-  const userText = toSimplified(sttData.text);
-  conversation.push({ role: 'user', content: userText });
-  transcriptDiv.textContent += `\n我: ${userText}`;
-  scrollTranscriptToBottom();
-  console.log('User said:', userText);
-  await getAssistantResponse(apiKey);
 }
 
-// call chat completion and handle reply
-async function getAssistantResponse(apiKey) {
-  const chatResponse = await fetch('https://api.openai.com/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${apiKey}`
-    },
-    body: JSON.stringify({
-      model: 'gpt-4o',
-      messages: conversation
-    })
-  });
-  const chatData = await chatResponse.json();
-  const assistantText = toSimplified(chatData.choices[0].message.content);
-  conversation.push({ role: 'assistant', content: assistantText });
-  transcriptDiv.textContent += `\n老师: ${assistantText}`;
-  lastAssistantText = assistantText;
-  repeatBtn.disabled = false;
-  scrollTranscriptToBottom();
-  console.log('Assistant:', assistantText);
-  await speakAssistantText(apiKey, assistantText);
-}
+recordButton.addEventListener('click', () => {
+  if (!isRecording) {
+    startRecording();
+  } else {
+    mediaRecorder?.stop();
+    statusText.textContent = 'Finishing recording…';
+  }
+});
 
-// use OpenAI TTS to read reply aloud
-async function speakAssistantText(apiKey, text) {
-  talkBtn.textContent = '老师正在讲话 (Teacher is speaking)...';
-  talkBtn.disabled = true;
-  repeatBtn.disabled = true;
-  translateBtn.disabled = true;
-  const ttsResponse = await fetch('https://api.openai.com/v1/audio/speech', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${apiKey}`
-    },
-    body: JSON.stringify({
-      model: 'gpt-4o-mini-tts',
-      input: text,
-      voice: 'nova',
-      instructions: 'Speak very slowly.'
-    })
-  });
-  const ttsBlob = await ttsResponse.blob();
-  const url = URL.createObjectURL(ttsBlob);
-  ttsAudio.src = url;
-  await ttsAudio.play();
-  console.log('Playing assistant audio');
-}
+normalBtn.addEventListener('click', playNormal);
+echoBtn.addEventListener('click', playEcho);
+robotBtn.addEventListener('click', playRobot);
+chipmunkBtn.addEventListener('click', playChipmunk);
+deepBtn.addEventListener('click', playDeep);
+
+initMic();


### PR DESCRIPTION
## Summary
- redesign the landing page with a clear vocoder-focused layout, typography, and helpful messaging
- add streamlined recording flow with permission handling, status updates, and session log entries
- enable local Web Audio playback with clean, echo, robot, chipmunk, and deep effect options

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69333fd603248321b45db203b0462b04)